### PR TITLE
Fix getting project configurations.

### DIFF
--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/ProjectTypeTable.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/ProjectTypeTable.cs
@@ -134,7 +134,7 @@ internal sealed partial class ProjectTypeTable
     }
 
     // Gets all of the configuration rules that apply to the project.
-    internal ConfigurationRuleFollower GetProjectConfigurationRules(SolutionProjectModel projectModel)
+    internal ConfigurationRuleFollower GetProjectConfigurationRules(SolutionProjectModel projectModel, bool excludeProjectSpecificRules = false)
     {
         // Rules are ordered most general to most specific.
         if (this.TryGetProjectType(projectModel, out ProjectType? type, out _))
@@ -152,6 +152,13 @@ internal sealed partial class ProjectTypeTable
 
             // Get the default rules in the solution. These intentionally are higher priority than type rules.
             rules.AddRange(this.defaultRules);
+
+            // Gets the rules defined on this project model.
+            if (projectModel.ProjectConfigurationRules is not null && !excludeProjectSpecificRules)
+            {
+                rules.AddRange(projectModel.ProjectConfigurationRules);
+            }
+
             return new ConfigurationRuleFollower(rules);
         }
         else

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.cs
@@ -164,7 +164,7 @@ internal sealed partial class SolutionConfigurationMap
 #endif
             this.mappings = new ProjectConfigMapping[configMap.matrixSize];
 
-            ConfigurationRuleFollower projectTypeRules = configMap.solutionModel.ProjectTypeTable.GetProjectConfigurationRules(projectModel);
+            ConfigurationRuleFollower projectTypeRules = configMap.solutionModel.ProjectTypeTable.GetProjectConfigurationRules(projectModel, excludeProjectSpecificRules: true);
             isConfigurable = projectTypeRules.GetIsBuildable() ?? true;
 
             for (int iPlatform = 0; iPlatform < configMap.PlatformsCount; iPlatform++)

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionProjectModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionProjectModel.cs
@@ -154,7 +154,7 @@ public sealed class SolutionProjectModel : SolutionItemModel
 
         return (
             projectTypeRules.GetProjectBuildType(solutionBuildType, solutionPlatform) ?? solutionBuildType,
-            projectTypeRules.GetProjectPlatform(solutionPlatform, solutionPlatform) ?? solutionPlatform,
+            projectTypeRules.GetProjectPlatform(solutionBuildType, solutionPlatform) ?? solutionPlatform,
             projectTypeRules.GetIsBuildable(solutionBuildType, solutionPlatform) ?? true,
             projectTypeRules.GetIsDeployable(solutionBuildType, solutionPlatform) ?? false);
     }

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Configurations.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Configurations.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.SolutionPersistence.Model;
+using Xunit;
+
+namespace Serialization;
+
+public class Configurations
+{
+    /// <summary>
+    /// Tests the <see cref="SolutionProjectModel.GetProjectConfiguration(string, string)"/> API.
+    /// </summary>
+    [Fact]
+    public void ProjectConfigurations()
+    {
+        const string platform = "TestPlatform";
+        const string buildType = "Debug";
+        const string projectPlatform = "ProjectTestPlatform";
+
+        // Create a simple solution with a single project.
+        SolutionModel solutionModel = new SolutionModel();
+
+        solutionModel.AddPlatform(platform);
+        solutionModel.AddPlatform("Any CPU");
+
+        solutionModel.AddBuildType(buildType);
+        solutionModel.AddBuildType("Release");
+
+        SolutionProjectModel project = solutionModel.AddProject(@"Foo\Foo.csproj", null);
+
+        // Add some project configurations for a specific solution configuration.
+        project.AddProjectConfigurationRule(new ConfigurationRule(BuildDimension.Build, buildType, platform, bool.TrueString));
+        project.AddProjectConfigurationRule(new ConfigurationRule(BuildDimension.Deploy, buildType, platform, bool.TrueString));
+        project.AddProjectConfigurationRule(new ConfigurationRule(BuildDimension.BuildType, buildType, platform, buildType));
+        project.AddProjectConfigurationRule(new ConfigurationRule(BuildDimension.Platform, buildType, platform, projectPlatform));
+
+        Assert.NotNull(project.ProjectConfigurationRules);
+        Assert.Equal(4, project.ProjectConfigurationRules.Count);
+
+        // Remove implied configurations.
+        solutionModel.DistillProjectConfigurations();
+
+        Assert.Equal(2, project.ProjectConfigurationRules.Count);
+
+        // Verify set configurations are still there.
+        (string BuildType, string Platform, bool Build, bool Deploy) projectConfig = project.GetProjectConfiguration(buildType, platform);
+        Assert.True(projectConfig.Build);
+        Assert.True(projectConfig.Deploy);
+        Assert.Equal(buildType, projectConfig.BuildType);
+        Assert.Equal(projectPlatform, projectConfig.Platform);
+    }
+}


### PR DESCRIPTION
The SolutionProjectModel.GetProjectConfiguration API was returning the wrong results because it did not load the full set of configuration rules and had a typo.
Added a test to validate the API.