### PR TITLE
Validate names when manipulating projects and folders in the model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ For the most part any serializer specific concepts are removed from the model, b
 
 See [Samples Wiki](https://github.com/microsoft/vs-solutionpersistence/wiki/Samples)
 
+## Trademark
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow Microsoft’s Trademark & Brand Guidelines. Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.
+

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Errors.Designer.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Errors.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.VisualStudio.SolutionPersistence {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An element with the same key already exists..
+        /// </summary>
+        internal static string DuplicateKey {
+            get {
+                return ResourceManager.GetString("DuplicateKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Duplicate name &apos;{0}&apos; for project type &apos;{1}&apos;..
         /// </summary>
         internal static string DuplicateName_Args2 {
@@ -142,6 +151,15 @@ namespace Microsoft.VisualStudio.SolutionPersistence {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Only ASCII, UTF-8, and Unicode encodings are supported for serializing &apos;.sln&apos; files..
+        /// </summary>
+        internal static string InvalidEncoding {
+            get {
+                return ResourceManager.GetString("InvalidEncoding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Solution folder path &apos;{0}&apos; must start and end with &apos;/&apos;..
         /// </summary>
         internal static string InvalidFolderPath_Args1 {
@@ -160,7 +178,7 @@ namespace Microsoft.VisualStudio.SolutionPersistence {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Missing or invalid &apos;{0}&apos; attribute in type &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Missing or invalid &apos;{0}&apos; item in type &apos;{1}&apos;..
         /// </summary>
         internal static string InvalidItemRef_Args2 {
             get {

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Errors.resx
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Errors.resx
@@ -160,7 +160,7 @@
     <value>Circular dependency found for '{0}'.</value>
   </data>
   <data name="InvalidItemRef_Args2" xml:space="preserve">
-    <value>Missing or invalid '{0}' attribute in type '{1}'.</value>
+    <value>Missing or invalid '{0}' item in type '{1}'.</value>
   </data>
   <data name="DuplicateItemRef_Args2" xml:space="preserve">
     <value>Duplicate item '{0}' of type '{1}'.</value>
@@ -198,5 +198,11 @@
   </data>
   <data name="InvalidModelItem" xml:space="preserve">
     <value>Model does not belong to this solution.</value>
+  </data>
+  <data name="InvalidEncoding" xml:space="preserve">
+    <value>Only ASCII, UTF-8, and Unicode encodings are supported for serializing '.sln' files.</value>
+  </data>
+  <data name="DuplicateKey" xml:space="preserve">
+    <value>An element with the same key already exists.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/ModelHelper.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/ModelHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.SolutionPersistence.Model;
 internal static class ModelHelper
 {
     // Generically finds the item in the list by itemRef and returns it, otherwise null.
-    internal static T? FindByItemRef<T>(IReadOnlyList<T>? items, string itemRef, Func<T, string> getItemRef)
+    internal static T? FindByItemRef<T>(IReadOnlyList<T>? items, string itemRef, Func<T, string> getItemRef, bool ignoreCase)
         where T : notnull
     {
         if (items is null)
@@ -17,9 +17,10 @@ internal static class ModelHelper
             return default;
         }
 
+        StringComparer comparer = ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
         foreach (T item in items.GetStructEnumerable())
         {
-            if (StringComparer.Ordinal.Equals(getItemRef(item), itemRef))
+            if (comparer.Equals(getItemRef(item), itemRef))
             {
                 return item;
             }
@@ -29,22 +30,22 @@ internal static class ModelHelper
     }
 
     // Returns the itemRef string in the list if it exists, otherwise null.
-    internal static string? FindByItemRef(IReadOnlyList<string>? items, string itemRef)
+    internal static string? FindByItemRef(IReadOnlyList<string>? items, string itemRef, bool ignoreCase)
     {
-        return FindByItemRef(items, itemRef, x => x);
+        return FindByItemRef(items, itemRef, x => x, ignoreCase);
     }
 
     // Finds the item in the SolutionItemModel list by itemRef and returns it, otherwise null.
     internal static T? FindByItemRef<T>(this IReadOnlyList<T>? items, string itemRef)
         where T : SolutionItemModel
     {
-        return FindByItemRef(items, itemRef, x => x.ItemRef);
+        return FindByItemRef(items, itemRef, x => x.ItemRef, ignoreCase: true);
     }
 
     // Finds the item in the list of property sets by itemRef and returns it, otherwise null.
     internal static SolutionPropertyBag? FindByItemRef(this IReadOnlyList<SolutionPropertyBag>? items, string itemRef)
     {
-        return FindByItemRef(items, itemRef, x => x.Id);
+        return FindByItemRef(items, itemRef, x => x.Id, ignoreCase: false);
     }
 
     internal static string GetDisplayName(this ProjectType projectType)

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.cs
@@ -122,7 +122,7 @@ internal sealed partial class SolutionConfigurationMap
     {
         if (index.MatrixIndex < 0 || index.MatrixIndex >= this.matrixSize)
         {
-            throw new ArgumentOutOfRangeException(nameof(index), "Bug, invalid configuration index");
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         int config = index.MatrixIndex / this.PlatformsCount;
@@ -134,7 +134,7 @@ internal sealed partial class SolutionConfigurationMap
     {
         if (index.MatrixIndex < 0 || index.MatrixIndex >= this.matrixSize)
         {
-            throw new ArgumentOutOfRangeException(nameof(index), "Bug, invalid configuration index");
+            throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         int plat = index.MatrixIndex % this.PlatformsCount;

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionException.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionException.cs
@@ -97,4 +97,10 @@ public class SolutionException : FormatException
             new SolutionException(message, innerException) { Line = lineInfo.LineNumber, Column = lineInfo.LinePosition, File = location.Root.FullPath } :
             new SolutionException(message, innerException) { File = location?.Root.FullPath };
     }
+
+    // Checks if an exception caught during serialization should be wrapped by a SolutionException to add position information.
+    internal static bool ShouldWrap(Exception ex)
+    {
+        return ex is not SolutionException and not OperationCanceledException;
+    }
 }

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionItemModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionItemModel.cs
@@ -59,7 +59,7 @@ public abstract class SolutionItemModel : PropertyContainerModel
             {
                 if (this.Solution.FindItemById(value) is not null)
                 {
-                    throw new ArgumentException(@"An item with the same Id already exists in the solution.", nameof(value));
+                    throw new ArgumentException(string.Format(Errors.DuplicateItemRef_Args2, value, this.GetType().Name), nameof(value));
                 }
 
                 Guid? oldId = this.id ?? this.defaultId;
@@ -80,17 +80,17 @@ public abstract class SolutionItemModel : PropertyContainerModel
     public abstract string ActualDisplayName { get; }
 
     /// <summary>
-    /// Gets a unique reference to the item in the solution.
-    /// This is designed as a replacement to Id and provides a human readable reference to the item.
-    /// </summary>
-    public abstract string ItemRef { get; }
-
-    /// <summary>
     /// Gets the project type id of the item.
     /// </summary>
     public abstract Guid TypeId { get; }
 
     internal SolutionItemModel BeSolutionItemModel => this;
+
+    /// <summary>
+    /// Gets a unique reference to the item in the solution.
+    /// This is designed as a replacement to Id and provides a human readable reference to the item.
+    /// </summary>
+    internal abstract string ItemRef { get; }
 
     private Guid DefaultId => this.defaultId ??= this.GetDefaultId();
 

--- a/src/Microsoft.VisualStudio.SolutionPersistence/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 abstract Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel.ActualDisplayName.get -> string!
-abstract Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel.ItemRef.get -> string!
 abstract Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel.TypeId.get -> System.Guid
 Microsoft.VisualStudio.SolutionPersistence.ISolutionSerializer
 Microsoft.VisualStudio.SolutionPersistence.ISolutionSerializer.CreateModelExtension() -> Microsoft.VisualStudio.SolutionPersistence.Model.ISerializerModelExtension!
@@ -60,6 +59,7 @@ Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.AddFile(str
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.Files.get -> System.Collections.Generic.IReadOnlyList<string!>?
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.Name.get -> string!
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.Name.set -> void
+Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.Path.get -> string!
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.RemoveFile(string! file) -> bool
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel.Id.get -> System.Guid
@@ -77,8 +77,9 @@ Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.BuildTypes.get ->
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.Description.get -> string?
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.Description.set -> void
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.DistillProjectConfigurations() -> void
+Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.FindFolder(string! path) -> Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel?
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.FindItemById(System.Guid id) -> Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel?
-Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.FindItemByItemRef(string! itemRef) -> Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel?
+Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.FindProject(string! path) -> Microsoft.VisualStudio.SolutionPersistence.Model.SolutionProjectModel?
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.MinVsVersion.get -> string?
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.MinVsVersion.set -> void
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.Platforms.get -> System.Collections.Generic.IReadOnlyList<string!>!
@@ -150,10 +151,8 @@ Microsoft.VisualStudio.SolutionPersistence.Serializer.Xml.SlnxSerializerSettings
 Microsoft.VisualStudio.SolutionPersistence.Serializer.Xml.SlnxSerializerSettings.PreserveWhitespace.init -> void
 Microsoft.VisualStudio.SolutionPersistence.Serializer.Xml.SlnxSerializerSettings.SlnxSerializerSettings() -> void
 override Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.ActualDisplayName.get -> string!
-override Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.ItemRef.get -> string!
 override Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.TypeId.get -> System.Guid
 override Microsoft.VisualStudio.SolutionPersistence.Model.SolutionProjectModel.ActualDisplayName.get -> string!
-override Microsoft.VisualStudio.SolutionPersistence.Model.SolutionProjectModel.ItemRef.get -> string!
 override Microsoft.VisualStudio.SolutionPersistence.Model.SolutionProjectModel.TypeId.get -> System.Guid
 readonly Microsoft.VisualStudio.SolutionPersistence.Model.ConfigurationRule.Dimension -> Microsoft.VisualStudio.SolutionPersistence.Model.BuildDimension
 readonly Microsoft.VisualStudio.SolutionPersistence.Model.ConfigurationRule.ProjectValue -> string!

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.cs
@@ -44,7 +44,7 @@ internal sealed partial class SlnFileV12Serializer : SingleFileSerializerBase<Sl
                 encoding.CodePage != Encoding.UTF8.CodePage &&
                 encoding.CodePage != Encoding.Unicode.CodePage)
             {
-                throw new ArgumentException("Only ASCII, UTF-8, and Unicode encodings are supported.", nameof(settings));
+                throw new ArgumentException(Errors.InvalidEncoding, nameof(settings));
             }
 
             // Make sure ASCII encoding always has exception fallback.

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/ItemConfigurationRulesList.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/ItemConfigurationRulesList.cs
@@ -20,7 +20,7 @@ internal struct ItemConfigurationRulesList
     {
     }
 
-    internal void Add(XmlConfiguration configuration)
+    internal readonly void Add(XmlConfiguration configuration)
     {
         switch (configuration)
         {
@@ -64,7 +64,7 @@ internal struct ItemConfigurationRulesList
                 decoratorItems: ref configurations,
                 decoratorElementName: dimensionElementName,
                 getItemRefs: static (config) => config.ToList(x => x.ItemRef),
-                getModelItem: static (configs, itemRef) => ModelHelper.FindByItemRef(configs, itemRef, x => x.ItemRef).Item,
+                getModelItem: static (configs, itemRef) => ModelHelper.FindByItemRef(configs, itemRef, x => x.ItemRef, ignoreCase: true).Item,
                 applyModelToXml: static (newConfiguration, modelConfiguration) => newConfiguration.ApplyModelToXml(modelConfiguration));
         }
     }

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlConfigurations.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlConfigurations.cs
@@ -109,7 +109,7 @@ internal sealed class XmlConfigurations(SlnxFile root, XmlElement element) :
             decoratorItems: ref this.buildType,
             decoratorElementName: Keyword.BuildType,
             getItemRefs: static (modelSolution) => modelSolution.IsBuildTypeImplicit() ? null : new List<string>(modelSolution.BuildTypes),
-            getModelItem: static (modelSolution, itemRef) => ModelHelper.FindByItemRef(modelSolution.BuildTypes, itemRef),
+            getModelItem: static (modelSolution, itemRef) => ModelHelper.FindByItemRef(modelSolution.BuildTypes, itemRef, ignoreCase: true),
             applyModelToXml: null);
 
         // Platforms
@@ -118,7 +118,7 @@ internal sealed class XmlConfigurations(SlnxFile root, XmlElement element) :
             decoratorItems: ref this.platforms,
             decoratorElementName: Keyword.Platform,
             getItemRefs: static (modelSolution) => modelSolution.IsPlatformImplicit() ? null : new List<string>(modelSolution.Platforms),
-            getModelItem: static (modelSolution, itemRef) => ModelHelper.FindByItemRef(modelSolution.Platforms, itemRef),
+            getModelItem: static (modelSolution, itemRef) => ModelHelper.FindByItemRef(modelSolution.Platforms, itemRef, ignoreCase: true),
             applyModelToXml: null);
 
         // Project Types
@@ -127,7 +127,7 @@ internal sealed class XmlConfigurations(SlnxFile root, XmlElement element) :
             ref this.projectTypes,
             Keyword.ProjectType,
             getItemRefs: static (types) => types.ToList(static x => x.ItemRef),
-            getModelItem: static (items, itemRef) => ModelHelper.FindByItemRef(items, itemRef, x => x.ItemRef).Item,
+            getModelItem: static (items, itemRef) => ModelHelper.FindByItemRef(items, itemRef, x => x.ItemRef, ignoreCase: false).Item,
             applyModelToXml: static (newProjectTypes, newValue) => newProjectTypes.ApplyModelToXml(newValue));
 
         return modified;

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlContainer.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlContainer.cs
@@ -59,7 +59,7 @@ internal abstract partial class XmlContainer(SlnxFile root, XmlElement element, 
 
         if (validateItemRef && !xmlDecorator.IsValid())
         {
-            throw new ArgumentException($"Invalid item reference {itemRef} for {xmlDecorator.ElementName}");
+            throw new ArgumentException(string.Format(Errors.InvalidItemRef_Args2, itemRef, xmlDecorator.ElementName));
         }
 
         xmlDecorator.UpdateFromXml();

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlProject.ApplyModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlProject.ApplyModel.cs
@@ -37,7 +37,7 @@ internal sealed partial class XmlProject
             decoratorItems: ref this.buildDependencies,
             decoratorElementName: Keyword.BuildDependency,
             getItemRefs: static (dependencies) => [.. dependencies],
-            getModelItem: static (dependencies, itemRef) => ModelHelper.FindByItemRef(dependencies, itemRef),
+            getModelItem: static (dependencies, itemRef) => ModelHelper.FindByItemRef(dependencies, itemRef, ignoreCase: true),
             applyModelToXml: null);
 
         // Configurations

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlSolution.ApplyModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlSolution.ApplyModel.cs
@@ -52,7 +52,7 @@ internal sealed partial class XmlSolution
             ref this.Projects,
             Keyword.Project,
             getItemRefs: static (modelProjects) => modelProjects.WhereToList((x, _) => x.Item.Parent is null, (x, _) => x.ItemRef, false),
-            getModelItem: static (modelProjects, itemRef) => ModelHelper.FindByItemRef(modelProjects, itemRef, x => x.ItemRef),
+            getModelItem: static (modelProjects, itemRef) => ModelHelper.FindByItemRef(modelProjects, itemRef, x => x.ItemRef, ignoreCase: true),
             applyModelToXml: static (newProject, newValue) => newProject.ApplyModelToXml(newValue.Item));
 
         // Properties

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Utilities/Lictionary`2.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Utilities/Lictionary`2.cs
@@ -43,7 +43,7 @@ internal readonly struct Lictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TV
         {
             if (this.comparer.Equals(lastEntry, entry))
             {
-                throw new ArgumentException("Duplicate property name " + lastEntry.Key, nameof(values));
+                throw new ArgumentException(Errors.DuplicateKey, nameof(values));
             }
 
             lastEntry = entry;
@@ -106,7 +106,7 @@ internal readonly struct Lictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TV
     {
         if (!this.TryAdd(key, value))
         {
-            throw new ArgumentException("Duplicate property name has " + key, nameof(key));
+            throw new ArgumentException(Errors.DuplicateKey, nameof(key));
         }
     }
 

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Microsoft.VisualStudio.SolutionPersistence.Tests.csproj
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Microsoft.VisualStudio.SolutionPersistence.Tests.csproj
@@ -27,4 +27,10 @@
     <EmbeddedResource Include="SlnAssets\**" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="SlnAssets\Invalid\SolutionFolder-NoEndSlash.slnx.xml" />
+    <None Remove="SlnAssets\Invalid\SolutionFolder-NoStartSlash.slnx.xml" />
+    <None Remove="SlnAssets\Invalid\SolutionFolder-WrongSlash.slnx.xml" />
+  </ItemGroup>
+
 </Project>

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Configurations.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Configurations.cs
@@ -62,13 +62,13 @@ public sealed class Configurations
 
         SolutionModel missingModel = await SolutionSerializers.SlnFileV12.OpenAsync(missing.Stream, CancellationToken.None);
 
-        SolutionProjectModel? goodProject = (SolutionProjectModel?)missingModel.FindItemByItemRef(Path.Join("Good", "Good.vcxproj"));
+        SolutionProjectModel? goodProject = missingModel.FindProject(Path.Join("Good", "Good.vcxproj"));
         Assert.NotNull(goodProject);
 
-        SolutionProjectModel? missingProject = (SolutionProjectModel?)missingModel.FindItemByItemRef(Path.Join("Missing", "Missing.vcxproj"));
+        SolutionProjectModel? missingProject = missingModel.FindProject(Path.Join("Missing", "Missing.vcxproj"));
         Assert.NotNull(missingProject);
 
-        SolutionProjectModel? partialProject = (SolutionProjectModel?)missingModel.FindItemByItemRef(Path.Join("Partial", "Partial.vcxproj"));
+        SolutionProjectModel? partialProject = missingModel.FindProject(Path.Join("Partial", "Partial.vcxproj"));
         Assert.NotNull(partialProject);
 
         // Debug|x86

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Folders.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Folders.cs
@@ -165,4 +165,46 @@ public sealed class Folders
         ArgumentException ex = Assert.Throws<ArgumentException>(() => folderThis.MoveToFolder(folderNested));
         Assert.StartsWith(Errors.CannotMoveFolderToChildFolder, ex.Message);
     }
+
+    /// <summary>
+    /// Validate changing a folder name.
+    /// Make sure it detects duplicates.
+    /// </summary>
+    [Fact]
+    public void ChangeFolderName()
+    {
+        SolutionModel solution = new SolutionModel();
+
+        SolutionFolderModel folderA = solution.AddFolder("/A/");
+        SolutionFolderModel folderB = solution.AddFolder("/B/");
+        SolutionFolderModel folderNestedA = solution.AddFolder("/A/Nested/Deep/");
+        SolutionFolderModel folderNestedB = solution.AddFolder("/B/Nested/Deep/");
+
+        // Try case exact
+        {
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => folderB.Name = "A");
+            Assert.StartsWith(string.Format(Errors.DuplicateItemRef_Args2, "/A/", "Folder"), ex.Message);
+
+            Assert.Equal("/B/Nested/Deep/", folderNestedB.Path);
+        }
+
+        // Try case insensitive
+        {
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => folderB.Name = "a");
+            Assert.StartsWith(string.Format(Errors.DuplicateItemRef_Args2, "/a/", "Folder"), ex.Message);
+
+            Assert.Equal("/B/Nested/Deep/", folderNestedB.Path);
+        }
+
+        Assert.Equal("/A/Nested/Deep/", folderNestedA.Path);
+        Assert.Equal("/B/Nested/Deep/", folderNestedB.Path);
+
+        // Try a successful rename.
+        folderB.Name = "C";
+
+        Assert.Equal("C", folderB.Name);
+        Assert.Equal("/C/", folderB.Path);
+        Assert.Equal("/A/Nested/Deep/", folderNestedA.Path);
+        Assert.Equal("/C/Nested/Deep/", folderNestedB.Path);
+    }
 }

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/InvalidSolutions.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/InvalidSolutions.cs
@@ -91,4 +91,23 @@ public sealed class InvalidSolutions
 
         AssertSolutionsAreEqual(SlnAssets.ClassicSlnMin.ToLines(), reserializedSolution);
     }
+
+    [Fact]
+    public async Task SolutionFolderAsync()
+    {
+        ResourceStream noEndSlash = SlnAssets.LoadResource(@"Invalid\SolutionFolder-NoEndSlash.slnx");
+        SolutionException exNoEndSlash = await Assert.ThrowsAsync<SolutionException>(
+            async () => _ = await SolutionSerializers.SlnXml.OpenAsync(noEndSlash.Stream, CancellationToken.None));
+        Assert.StartsWith(string.Format(Errors.InvalidFolderPath_Args1, @"/No/End/Slash"), exNoEndSlash.Message);
+
+        ResourceStream noStartSlash = SlnAssets.LoadResource(@"Invalid\SolutionFolder-NoStartSlash.slnx");
+        SolutionException exNoStartSlash = await Assert.ThrowsAsync<SolutionException>(
+            async () => _ = await SolutionSerializers.SlnXml.OpenAsync(noStartSlash.Stream, CancellationToken.None));
+        Assert.StartsWith(string.Format(Errors.InvalidFolderPath_Args1, @"No/Start/Slash/"), exNoStartSlash.Message);
+
+        ResourceStream wrongSlash = SlnAssets.LoadResource(@"Invalid\SolutionFolder-WrongSlash.slnx");
+        SolutionException exWrongSlash = await Assert.ThrowsAsync<SolutionException>(
+            async () => _ = await SolutionSerializers.SlnXml.OpenAsync(wrongSlash.Stream, CancellationToken.None));
+        Assert.StartsWith(string.Format(Errors.InvalidName, @"/Wrong\Slash/"), exWrongSlash.Message);
+    }
 }

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Project.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Project.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Serialization;
+
+/// <summary>
+/// Tests related to manipulating projects in the model.
+/// </summary>
+public sealed class Project
+{
+    [Fact]
+    public void AddProject()
+    {
+        string projectPath = Path.Join("..", "Folder", "Subfolder", "ProjectFileName.csproj");
+        string anotherProjectPath = Path.Join("..", "Folder", "Subfolder", "AnotherProjectFileName.csproj");
+
+        SolutionModel solution = new SolutionModel();
+        SolutionFolderModel folder = solution.AddFolder("/Solution Items/");
+        SolutionProjectModel project = solution.AddProject(projectPath, projectTypeName: null);
+        SolutionProjectModel anotherProject = solution.AddProject(anotherProjectPath, projectTypeName: null);
+
+        Assert.Equal("ProjectFileName", project.ActualDisplayName);
+        Assert.Empty(project.Type);
+
+        // Verify error if same project is added again.
+        {
+            Exception ex = Assert.Throws<ArgumentException>(() => solution.AddProject(projectPath, projectTypeName: null));
+            Assert.StartsWith(string.Format(Errors.DuplicateItemRef_Args2, projectPath, "Project"), ex.Message);
+        }
+
+        // Verify error if same project is added to folder.
+        {
+            Exception ex = Assert.Throws<ArgumentException>(() => solution.AddProject(projectPath, projectTypeName: null, folder: folder));
+            Assert.StartsWith(string.Format(Errors.DuplicateItemRef_Args2, projectPath, "Project"), ex.Message);
+        }
+
+        // Verify error if same project is added with different case..
+        {
+            string projectPathUpper = projectPath.ToUpperInvariant();
+            Exception ex = Assert.Throws<ArgumentException>(() => solution.AddProject(projectPathUpper, projectTypeName: null));
+            Assert.StartsWith(string.Format(Errors.DuplicateItemRef_Args2, projectPathUpper, "Project"), ex.Message);
+        }
+
+        // Try chaging a path to an existing project.
+        {
+            Exception ex = Assert.Throws<ArgumentException>(() => anotherProject.FilePath = project.FilePath);
+            Assert.StartsWith(string.Format(Errors.DuplicateItemRef_Args2, projectPath, "Project"), ex.Message);
+        }
+    }
+
+    [Fact(Skip = "Broken")]
+    public async Task RemoveProjectAsync()
+    {
+        SolutionModel solution = await SolutionSerializers.SlnXml.OpenAsync(SlnAssets.XmlSlnxEverything.Stream, CancellationToken.None);
+
+        string toRemove = @"src\CoreMauiApp\CoreMauiApp.csproj";
+
+        SolutionProjectModel? projectToRemove = solution.FindProject(toRemove);
+        Assert.NotNull(projectToRemove);
+
+        Assert.True(solution.RemoveProject(projectToRemove));
+
+        (SolutionModel reserializedSolution, FileContents _) = await SaveAndReopenModelAsync(SolutionSerializers.SlnXml, solution);
+
+        Assert.Null(reserializedSolution.FindProject(toRemove));
+    }
+}

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Invalid/SolutionFolder-NoEndSlash.slnx.xml
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Invalid/SolutionFolder-NoEndSlash.slnx.xml
@@ -1,0 +1,3 @@
+<Solution>
+    <Folder Name="/No/End/Slash" />
+</Solution>

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Invalid/SolutionFolder-NoStartSlash.slnx.xml
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Invalid/SolutionFolder-NoStartSlash.slnx.xml
@@ -1,0 +1,3 @@
+<Solution>
+    <Folder Name="No/Start/Slash/" />
+</Solution>

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Invalid/SolutionFolder-WrongSlash.slnx.xml
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Invalid/SolutionFolder-WrongSlash.slnx.xml
@@ -1,0 +1,3 @@
+<Solution>
+    <Folder Name="/Wrong\Slash/" />
+</Solution>


### PR DESCRIPTION
- Projects and folders were validated when adding to the model, but this extends that to when they are manipulated in the model.
- Make sure exceptions from model are wrapped with SolutionException when raised during serialization to add location information to the error.
- Make some hardcoded errors localizable.
- Fix validation bug where it didn't check case correctly.
- Tidy some public APIs. Remove references to ItemRef as that concept should be internal.
- Add standard trademark disclaimer to readme
- Add tests