### PR TITLE
Fix getting configurations of projects with unknown project type.

### DIFF
--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/ProjectTypeTable.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/ProjectTypeTable.cs
@@ -161,9 +161,13 @@ internal sealed partial class ProjectTypeTable
 
             return new ConfigurationRuleFollower(rules);
         }
+        else if (!excludeProjectSpecificRules)
+        {
+            return new ConfigurationRuleFollower(projectModel.ProjectConfigurationRules);
+        }
         else
         {
-            return new ConfigurationRuleFollower([]);
+            return new ConfigurationRuleFollower(null);
         }
 
         void GetProjectTypeConfigurationRules(ProjectType? type, List<ConfigurationRule> rules)

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionProjectModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionProjectModel.cs
@@ -190,11 +190,12 @@ public sealed class SolutionProjectModel : SolutionItemModel
     {
         ConfigurationRuleFollower projectTypeRules = this.Solution.ProjectTypeTable.GetProjectConfigurationRules(this);
 
-        return (
-            MissingToNull(projectTypeRules.GetProjectBuildType(solutionBuildType, solutionPlatform) ?? solutionBuildType),
-            MissingToNull(projectTypeRules.GetProjectPlatform(solutionBuildType, solutionPlatform) ?? solutionPlatform),
-            projectTypeRules.GetIsBuildable(solutionBuildType, solutionPlatform) ?? true,
-            projectTypeRules.GetIsDeployable(solutionBuildType, solutionPlatform) ?? false);
+        string? buildType = MissingToNull(projectTypeRules.GetProjectBuildType(solutionBuildType, solutionPlatform) ?? solutionBuildType);
+        string? platform = MissingToNull(projectTypeRules.GetProjectPlatform(solutionBuildType, solutionPlatform) ?? solutionPlatform);
+        bool build = projectTypeRules.GetIsBuildable(solutionBuildType, solutionPlatform) ?? true;
+        bool deploy = projectTypeRules.GetIsDeployable(solutionBuildType, solutionPlatform) ?? false;
+
+        return (buildType, platform, build, deploy);
 
         static string? MissingToNull(string value) => value == BuildTypeNames.Missing ? null : value;
     }

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Configurations.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/Configurations.cs
@@ -121,4 +121,23 @@ public sealed class Configurations
             Assert.False(partial1.Deploy);
         }
     }
+
+    /// <summary>
+    /// Validate that the model can handle configurations on a project without a project type.
+    /// </summary>
+    [Fact]
+    public async Task UnknownProjectTypeWithConfigAsync()
+    {
+        ResourceStream projectTypeConfigResource = SlnAssets.LoadResource("ProjectTypeConfig.sln");
+
+        SolutionModel solution = await SolutionSerializers.SlnFileV12.OpenAsync(projectTypeConfigResource.Stream, CancellationToken.None);
+
+        SolutionProjectModel? project6 = solution.FindProject("Project6.wapproj");
+        Assert.NotNull(project6);
+
+        (string? BuildType, string? Platform, bool Build, bool Deploy) configs = project6.GetProjectConfiguration("Debug", "Win32");
+        Assert.Equal("Debug", configs.BuildType);
+        Assert.Equal("x86", configs.Platform);
+        Assert.True(configs.Build);
+    }
 }

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/ProjectTypeConfig.sln.txt
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/ProjectTypeConfig.sln.txt
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 17.0.31903.59
+Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "Project6", "Project6.wapproj", "{CA5CAD1A-224A-4171-B13A-F16E576FDD12}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|Win32.ActiveCfg = Debug|x86
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|Win32.Build.0 = Debug|x86
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|Win32.Deploy.0 = Debug|x86
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|x64.ActiveCfg = Debug|x64
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|x64.Build.0 = Debug|x64
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|x64.Deploy.0 = Debug|x64
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|x86.ActiveCfg = Debug|x86
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|x86.Build.0 = Debug|x86
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Debug|x86.Deploy.0 = Debug|x86
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Release|Win32.ActiveCfg = Release|x86
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Release|x64.ActiveCfg = Release|x64
+		{CA5CAD1A-224A-4171-B13A-F16E576FDD12}.Release|x86.ActiveCfg = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/ProjectTypeConfig.slnx.xml
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/ProjectTypeConfig.slnx.xml
@@ -1,0 +1,12 @@
+<Solution>
+  <Configurations>
+    <Platform Name="Win32" />
+    <Platform Name="x64" />
+    <Platform Name="x86" />
+  </Configurations>
+  <Project Path="Project6.wapproj" Type="c7167f0d-bc9f-4e6e-afe1-012c56b48db5">
+    <Platform Solution="*|Win32" Project="x86" />
+    <Build Solution="Release|*" Project="false" />
+    <Deploy Solution="Debug|*" />
+  </Project>
+</Solution>


### PR DESCRIPTION
If the project wasn't referencing a project type, it ignored the rules on the project.