### PR TITLE
Move distill rules from reader to writer.

### DIFF
--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/ConfigurationRuleFollower.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/ConfigurationRuleFollower.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.SolutionPersistence.Model;
 /// <summary>
 /// Helper to process configuration rules.
 /// </summary>
-internal readonly struct ConfigurationRuleFollower(IReadOnlyList<ConfigurationRule>? configurationRules)
+internal readonly ref struct ConfigurationRuleFollower(IReadOnlyList<ConfigurationRule>? configurationRules)
 {
     private readonly IReadOnlyList<ConfigurationRule>? configurationRules = configurationRules;
 

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.Rules.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.Rules.cs
@@ -31,7 +31,7 @@ internal sealed partial class SolutionConfigurationMap
     /// </summary>
     /// <param name="projectMappings">The mappings to update.</param>
     /// <param name="scopedRules">The rules to run, scoped to their effect.</param>
-    private void ApplyRules(in SolutionToProjectMappings projectMappings, in ScopedRules scopedRules)
+    private void ApplyRules(in SolutionToProjectMappings projectMappings, scoped in ScopedRules scopedRules)
     {
         int iBuildTypeBegin = scopedRules.BuildTypeIndex == ScopedRules.All ? 0 : scopedRules.BuildTypeIndex;
         int iBuildTypeEnd = scopedRules.BuildTypeIndex == ScopedRules.All ? this.BuildTypesCount : scopedRules.BuildTypeIndex + 1;

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionConfigurationMap.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.SolutionPersistence.Model;
 internal sealed partial class SolutionConfigurationMap
 {
     private readonly SolutionModel solutionModel;
-    private readonly Dictionary<string, int> buildTypesIndex = [];
-    private readonly Dictionary<string, int> platformsIndex = [];
+    private readonly Dictionary<string, int> buildTypesIndex;
+    private readonly Dictionary<string, int> platformsIndex;
 
     private readonly Dictionary<SolutionProjectModel, SolutionToProjectMappings> perProjectCurrent = [];
 
@@ -19,11 +19,13 @@ internal sealed partial class SolutionConfigurationMap
     internal SolutionConfigurationMap(SolutionModel solutionModel)
     {
         this.solutionModel = solutionModel;
+        this.buildTypesIndex = new Dictionary<string, int>(solutionModel.BuildTypes.Count);
         for (int i = 0; i < solutionModel.BuildTypes.Count; i++)
         {
             this.buildTypesIndex.Add(solutionModel.BuildTypes[i], i);
         }
 
+        this.platformsIndex = new Dictionary<string, int>(solutionModel.Platforms.Count);
         for (int i = 0; i < solutionModel.Platforms.Count; i++)
         {
             this.platformsIndex.Add(PlatformNames.Canonical(solutionModel.Platforms[i]), i);

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnV12Extensions.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnV12Extensions.cs
@@ -265,8 +265,6 @@ public static class SlnV12Extensions
                 {
                     ParseProjectConfigLine(solution, projectKey, projectValue);
                 }
-
-                solution.DistillProjectConfigurations();
             }
 
             // Applies a .SLN configuration line to the current project configuration.

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/SlnXMLSerializer.Writer.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/SlnXMLSerializer.Writer.cs
@@ -43,6 +43,8 @@ internal partial class SlnXmlSerializer
                 model.RemoveObsoleteProperties();
             }
 
+            model.DistillProjectConfigurations();
+
             // If this started as an XML document, merge the changes back into the original document.
             SlnxFile root = modelExtension?.Root ?? CreateNewSlnFile(fullPath, xmlSerializerSettings, model.StringTable);
 

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/ManipulateXmlKitchenSink.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/ManipulateXmlKitchenSink.cs
@@ -41,7 +41,7 @@ public class ManipulateXmlKitchenSink
 
             SolutionProjectModel? project = solution.FindProject(Path.Join("other", "Project4.nativeproj"));
             Assert.NotNull(project);
-            project.AddProjectConfigurationRule(new ConfigurationRule(BuildDimension.Platform, "*", "Z80", "Z80"));
+            project.AddProjectConfigurationRule(new ConfigurationRule(BuildDimension.Platform, "*", "Arm64", "Z80"));
 
             SolutionProjectModel? project3 = solution.FindProject("Project3.csproj");
             Assert.NotNull(project3);

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/SlnxWhitespace/KitchenSink-AddConfigurations.slnx.xml
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/SlnxWhitespace/KitchenSink-AddConfigurations.slnx.xml
@@ -52,7 +52,7 @@
             <BuildDependency Project="Project2.nativeproj" />
             <BuildDependency Project="Project3.csproj" />
             <BuildDependency Project="Project3.nativeproj" />
-            <Platform Solution="*|Z80" Project="Z80" />
+            <Platform Solution="*|Arm64" Project="Z80" />
         </Project>
         <Project Path="other/Project5.nativeproj" />
         <Project Path="other/Project6.nativeproj" />


### PR DESCRIPTION
Running DistillProjectConfigurations on each .SLN load was causing perf regressions in scenarios where this is not needed. Since this is only needed to simplify the model when saving to .SLNX, the call was moved from the sln reader to the slnx writer.

- A test was updated where the rule added to the slnx was removed by this change, the rule was updated to one that wouldn't be optimized out.