### PR TITLE
SolutionModel: Fix typo in error

### DIFF
--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionModel.cs
@@ -218,7 +218,7 @@ public sealed class SolutionModel : PropertyContainerModel
         Guid projectTypeId =
             Guid.TryParse(projectTypeName, out Guid projectTypeGuid) ? projectTypeGuid :
             this.ProjectTypeTable.GetProjectTypeId(projectTypeName, Path.GetExtension(filePath.AsSpan())) ??
-            throw new SolutionArgumentException(string.Format(Errors.InvalidProjectTypeReference_Args1, projectTypeName), nameof(projectTypeName), SolutionErrorType.InvalidProjectReference);
+            throw new SolutionArgumentException(string.Format(Errors.InvalidProjectTypeReference_Args1, projectTypeName), nameof(projectTypeName), SolutionErrorType.InvalidProjectTypeReference);
 
         return this.AddProject(filePath, projectTypeName ?? string.Empty, projectTypeId, folder);
     }


### PR DESCRIPTION
This fixes a typo in the error of an `InvalidProjectTypeReference` error