### PR TITLE
Folders: Add count of non-folder descendants

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.402",
+    "version": "9.0.101",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionFolderModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionFolderModel.cs
@@ -20,6 +20,7 @@ public sealed class SolutionFolderModel : SolutionItemModel
     {
         Argument.ThrowIfNullOrEmpty(name, nameof(name));
         this.name = name;
+        this.Children = [];
     }
 
     /// <summary>
@@ -36,7 +37,21 @@ public sealed class SolutionFolderModel : SolutionItemModel
         {
             this.files = [.. folderModel.Files];
         }
+
+        if (folderModel.Children is not null)
+        {
+            this.Children = [.. folderModel.Children];
+        }
+        else
+        {
+            this.Children = [];
+        }
     }
+
+    /// <summary>
+    /// Gets the children in this solution folder.
+    /// </summary>
+    public HashSet<SolutionItemModel> Children { get; private set; }
 
     /// <summary>
     /// Gets the files in this solution folder.
@@ -141,6 +156,29 @@ public sealed class SolutionFolderModel : SolutionItemModel
     public bool RemoveFile(string file)
     {
         return this.files is not null && this.files.Remove(file);
+    }
+
+    /// <summary>
+    /// Returns the number of non-folder SolutionItem descendants recursively (includes projects and files).
+    /// </summary>
+    /// <returns>Number of non-folder SolutionItem descendents.</returns>
+    public int CountNonFolderDescendants()
+    {
+        int count = 0;
+
+        foreach (SolutionItemModel item in this.Children)
+        {
+            if (item is SolutionFolderModel folderModel)
+            {
+                count += folderModel.CountNonFolderDescendants();
+            }
+            else
+            {
+                count++;
+            }
+        }
+
+        return count + (this.Files?.Count ?? 0);
     }
 
     internal override void OnItemRefChanged()

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionItemModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionItemModel.cs
@@ -10,6 +10,7 @@ public abstract class SolutionItemModel : PropertyContainerModel
 {
     private Guid? id;
     private Guid? defaultId;
+    private SolutionFolderModel? parent;
 
     private protected SolutionItemModel(SolutionModel solutionModel, SolutionFolderModel? parent)
     {
@@ -44,7 +45,20 @@ public abstract class SolutionItemModel : PropertyContainerModel
     /// <summary>
     /// Gets the parent solution folder.
     /// </summary>
-    public SolutionFolderModel? Parent { get; private set; }
+    public SolutionFolderModel? Parent
+    {
+        get
+        {
+            return this.parent;
+        }
+
+        private set
+        {
+            _ = this.parent?.Children.Remove(this);
+            this.parent = value;
+            _ = this.parent?.Children.Add(this);
+        }
+    }
 
     /// <summary>
     /// Gets or sets the unique Id of the item within the solution.

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionModel.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Model/SolutionModel.cs
@@ -652,6 +652,11 @@ public sealed class SolutionModel : PropertyContainerModel
 
     private bool RemoveItem(SolutionItemModel item)
     {
+        if (item.Parent != null)
+        {
+            _ = item.Parent.Children.Remove(item);
+        }
+
         _ = this.solutionItemsById.Remove(item.Id);
         return this.solutionItems.Remove(item);
     }

--- a/src/Microsoft.VisualStudio.SolutionPersistence/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/PublicAPI/PublicAPI.Unshipped.txt
@@ -35,3 +35,5 @@ Microsoft.VisualStudio.SolutionPersistence.Model.SolutionException.ErrorType.get
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionException.ErrorType.init -> void
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionException.SolutionException(string! message, Microsoft.VisualStudio.SolutionPersistence.Model.SolutionErrorType errorType) -> void
 Microsoft.VisualStudio.SolutionPersistence.Model.SolutionException.SolutionException(string! message, System.Exception! inner, Microsoft.VisualStudio.SolutionPersistence.Model.SolutionErrorType errorType) -> void
+Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.Children.get -> System.Collections.Generic.HashSet<Microsoft.VisualStudio.SolutionPersistence.Model.SolutionItemModel!>!
+Microsoft.VisualStudio.SolutionPersistence.Model.SolutionFolderModel.CountNonFolderDescendants() -> int


### PR DESCRIPTION
It might be useful to have a count of non-solutionfolder descendants. For example, if a program wants to remove all empty folders (and nested folders). 

This introduces the `Children` and `CountNonFolderDescendents()` members to `SolutionFolderModel`.

This is populated via the `Parent` member of `SolutionItemModel`, such that whenever an item's parent is set, the item is added to the parent's children as well. 