### PR TITLE
Handle spaces in GlobalSection definition.

### DIFF
--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.Reader.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.Reader.cs
@@ -491,7 +491,7 @@ internal sealed partial class SlnFileV12Serializer
             // So that is valid: ProjectSection ((( ))XXX===(())preProect
             // We have to keep that behaviour, only slight difference  will allow space in adition to tab at the end of name
             // With all wierd syntaxes old will accepet, it will not accept ProjectSection( Foo )  (but will do ) ProjectSection(  Foo) ...
-            StringSpan sectionName = tokenizer.NextToken(SlnConstants.SectionSeparators).Trim();
+            StringSpan sectionName = tokenizer.NextToken(SlnConstants.SectionSeparators2).Trim();
             this.SolutionAssert(!sectionName.IsEmpty, Errors.MissingSectionName);
             StringSpan sectionScopeStr = tokenizer.NextToken(SlnConstants.SectionSeparators).Trim();
             this.SolutionAssert(TryParseScope(sectionScopeStr, isSolution, out PropertiesScope scope), Errors.InvalidScope);

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/SampleMany.sln.txt
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/SampleMany.sln.txt
@@ -226,6 +226,9 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {210A5C78-8B93-42DA-8FB9-A667D3B01618}
 	EndGlobalSection
+	GlobalSection(DevPartner Solution Properties) = postSolution
+		SharedCPS\SharedCPS.vcxitems*{919107bb-2e8e-4dbb-ac5d-36ff8a211ffc}*SharedItemsImports = 9
+	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		CSharpShared\CSharpShared.projitems*{51cc7781-a8d3-4c60-8065-f3ceedba8032}*SharedItemsImports = 13
 		SharedCPS\SharedCPS.vcxitems*{919107bb-2e8e-4dbb-ac5d-36ff8a211ffc}*SharedItemsImports = 9

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/SampleMany.slnx.xml
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/SampleMany.slnx.xml
@@ -77,4 +77,7 @@
     </Project>
   </Folder>
   <Project Path="TestProjectRoot/TestProjectRoot.csproj" />
+  <Properties Name="DevPartner Solution Properties" Scope="PostLoad">
+    <Property Name="SharedCPS\SharedCPS.vcxitems*{919107bb-2e8e-4dbb-ac5d-36ff8a211ffc}*SharedItemsImports" Value="9" />
+  </Properties>
 </Solution>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.0",
+  "versionHeightOffset": "10",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
The tokenizer previously errored when the property name had spaces. I've added some tests to cover the scenario and fixed the bug.