### PR TITLE
Don't report error reading invalid project type guid in .sln files.

### DIFF
--- a/src/Microsoft.VisualStudio.SolutionPersistence/Errors.Designer.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Errors.Designer.cs
@@ -227,15 +227,6 @@ namespace Microsoft.VisualStudio.SolutionPersistence {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Missing or invalid project type guid..
-        /// </summary>
-        internal static string InvalidProjectType {
-            get {
-                return ResourceManager.GetString("InvalidProjectType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to ProjectType &apos;{0}&apos; not found..
         /// </summary>
         internal static string InvalidProjectTypeReference_Args1 {

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Errors.resx
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Errors.resx
@@ -129,10 +129,6 @@
     <value>Missing or invalid scope.</value>
     <comment>Error message</comment>
   </data>
-  <data name="InvalidProjectType" xml:space="preserve">
-    <value>Missing or invalid project type guid.</value>
-    <comment>Error message</comment>
-  </data>
   <data name="SyntaxError" xml:space="preserve">
     <value>Syntax error.</value>
     <comment>Error message</comment>

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.Reader.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.Reader.cs
@@ -525,7 +525,11 @@ internal sealed partial class SlnFileV12Serializer
             StringSpan projectType = tokenizer.NextToken(SlnConstants.ProjectSeparators);
 
             // but it must end with [sep]) ... checked later.
-            this.SolutionAssert(Guid.TryParse(projectType.ToString(), out Guid projectTypeId), Errors.InvalidProjectType);
+            if (!Guid.TryParse(projectType.ToString(), out Guid projectTypeId))
+            {
+                projectTypeId = Guid.Empty;
+                this.tarnished = true;
+            }
 
             // this just skips up to Display's name "App1" first quote, position at 'A". The TrimStart is extension to allow spaces before ')';
             // and yes, any characters are allowed for example // Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App1", valid bad format :P "App1\App1.csproj",


### PR DESCRIPTION
This was a behavior change between previous MSBuild and VS behavior. This serializer should not report an error if the project type is not a guid.