### PR TITLE
Preserve trailing tabs in property values.

### DIFF
--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.Reader.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/SlnV12/SlnFileV12Serializer.Reader.cs
@@ -173,9 +173,9 @@ internal sealed partial class SlnFileV12Serializer
                                 // original will load the solution as well, but will mark it as "tarnished" with implication to "isDirty" and such.
                                 propName = propName.Trim();
 
-                                // similar for values
-                                tokenizer.TrimStart();
-                                StringSpan propValue = tokenizer.Current;
+                                // Strip all leading spaces from the value, matching legacy parser behavior.
+                                // The legacy parser strips only spaces (not tabs), so tabs in the value are preserved.
+                                StringSpan propValue = tokenizer.Current.TrimStart(' ');
 
                                 // note: it does not strip trailing spaces for value. That was obvious bug, but in fact some could exploited it to store spaces at the end of values.
                                 // tokenizer.Trim(ref value);

--- a/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlProperty.cs
+++ b/src/Microsoft.VisualStudio.SolutionPersistence/Serializer/Xml/XmlDecorators/XmlProperty.cs
@@ -18,7 +18,7 @@ internal sealed partial class XmlProperty(SlnxFile root, XmlElement element) :
 
     internal string Value
     {
-        get => this.GetXmlAttribute(Keyword.Value) ?? string.Empty;
+        get => this.XmlElement.GetAttribute(Keyword.Value.ToXmlString());
         set => this.UpdateXmlAttribute(Keyword.Value, value);
     }
 

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/PropertyValueTabs.cs
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/Serialization/PropertyValueTabs.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Serialization;
+
+/// <summary>
+/// Tests that property values containing tab characters survive serialization roundtrips.
+/// </summary>
+public class PropertyValueTabs
+{
+    /// <summary>
+    /// Verifies that leading, trailing, and embedded tabs in property values survive a .slnx roundtrip.
+    /// </summary>
+    [Fact]
+    public async Task SlnxRoundTrip_TabsInPropertyValuesAsync()
+    {
+        SolutionModel solution = new SolutionModel();
+        SolutionPropertyBag props = solution.AddProperties("TestProps");
+        props.Add("LeadingTab", "\tHello");
+        props.Add("TrailingTab", "Hello\t");
+        props.Add("EmbeddedTabs", "foo=1\tbaz=value\tbar=2\t");
+
+        (SolutionModel reopened, FileContents _) = await SaveAndReopenModelAsync(SolutionSerializers.SlnXml, solution);
+
+        SolutionPropertyBag? roundTripped = reopened.FindProperties("TestProps");
+        Assert.NotNull(roundTripped);
+        Assert.Equal("\tHello", roundTripped["LeadingTab"]);
+        Assert.Equal("Hello\t", roundTripped["TrailingTab"]);
+        Assert.Equal("foo=1\tbaz=value\tbar=2\t", roundTripped["EmbeddedTabs"]);
+    }
+
+    /// <summary>
+    /// Verifies that leading, trailing, and embedded tabs in property values survive a .sln roundtrip.
+    /// </summary>
+    [Fact]
+    public async Task SlnRoundTrip_TabsInPropertyValuesAsync()
+    {
+        SolutionModel solution = new SolutionModel();
+        SolutionPropertyBag props = solution.AddProperties("TestProps");
+        props.Add("LeadingTab", "\tHello");
+        props.Add("TrailingTab", "Hello\t");
+        props.Add("EmbeddedTabs", "foo=1\tbaz=value\tbar=2\t");
+        solution.SerializerExtension = SolutionSerializers.SlnFileV12.CreateModelExtension();
+
+        (SolutionModel reopened, FileContents _) = await SaveAndReopenModelAsync(SolutionSerializers.SlnFileV12, solution);
+
+        SolutionPropertyBag? roundTripped = reopened.FindProperties("TestProps");
+        Assert.NotNull(roundTripped);
+        Assert.Equal("\tHello", roundTripped["LeadingTab"]);
+        Assert.Equal("Hello\t", roundTripped["TrailingTab"]);
+        Assert.Equal("foo=1\tbaz=value\tbar=2\t", roundTripped["EmbeddedTabs"]);
+    }
+}

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Everything.sln.txt
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Everything.sln.txt
@@ -42,7 +42,7 @@ EndProject
 Project("{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}") = "devenv", "..\..\..\..\..\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe", "{78E62256-49D8-4CC1-8491-D7285015B09E}"
 	ProjectSection(DebuggerProjectSystem) = preProject
 		AttachLaunchAction = No
-		Environment = Default
+		Environment = foo=1	baz=value	bar=2	
 		Executable = C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe
 		IORedirection = Auto
 		LaunchingEngine = fb0d4648-f776-4980-95f8-bb7f36ebc1ee

--- a/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Everything.slnx.xml
+++ b/test/Microsoft.VisualStudio.SolutionPersistence.Tests/SlnAssets/Everything.slnx.xml
@@ -23,7 +23,7 @@
     <Platform Project="x64" />
     <Properties Name="DebuggerProjectSystem">
       <Property Name="AttachLaunchAction" Value="No" />
-      <Property Name="Environment" Value="Default" />
+      <Property Name="Environment" Value="foo=1&#x9;baz=value&#x9;bar=2&#x9;" />
       <Property Name="Executable" Value="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" />
       <Property Name="IORedirection" Value="Auto" />
       <Property Name="LaunchingEngine" Value="fb0d4648-f776-4980-95f8-bb7f36ebc1ee" />


### PR DESCRIPTION
Fixes a bug where tabs were stripped from property values. This bug breaks setting environment variables in 'exe' projects in Visual Studio.