### PR TITLE
Enforce CFS network isolation policies across all pipelines

### DIFF
--- a/azure-pipelines/archive-sourcecode.yml
+++ b/azure-pipelines/archive-sourcecode.yml
@@ -35,6 +35,13 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      # Enforce CFS (Compliant Feed Service) network isolation to satisfy SFI-ES4.2.4.
+      # CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.).
+      # CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com).
+      # CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other forbidden endpoints.
+      # See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-cfs-s360-items
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
 

--- a/azure-pipelines/libtemplate-update.yml
+++ b/azure-pipelines/libtemplate-update.yml
@@ -30,6 +30,13 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
+    settings:
+      # Enforce CFS (Compliant Feed Service) network isolation to satisfy SFI-ES4.2.4.
+      # CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.).
+      # CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com).
+      # CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other forbidden endpoints.
+      # See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-cfs-s360-items
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool:
         name: AzurePipelines-EO

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -45,6 +45,13 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      # Enforce CFS (Compliant Feed Service) network isolation to satisfy SFI-ES4.2.4.
+      # CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.).
+      # CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com).
+      # CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other forbidden endpoints.
+      # See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-cfs-s360-items
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       codeSignValidation:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -20,6 +20,13 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      # Enforce CFS (Compliant Feed Service) network isolation to satisfy SFI-ES4.2.4.
+      # CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.).
+      # CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com).
+      # CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other forbidden endpoints.
+      # See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-cfs-s360-items
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
 

--- a/azure-pipelines/unofficial.yml
+++ b/azure-pipelines/unofficial.yml
@@ -55,6 +55,13 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
+    settings:
+      # Enforce CFS (Compliant Feed Service) network isolation to satisfy SFI-ES4.2.4.
+      # CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.).
+      # CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com).
+      # CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other forbidden endpoints.
+      # See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-cfs-s360-items
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       credscan:

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -22,6 +22,13 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      # Enforce CFS (Compliant Feed Service) network isolation to satisfy SFI-ES4.2.4.
+      # CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.).
+      # CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com).
+      # CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other forbidden endpoints.
+      # See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-cfs-s360-items
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       sbom:

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -26,6 +26,13 @@ variables:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
+    settings:
+      # Enforce CFS (Compliant Feed Service) network isolation to satisfy SFI-ES4.2.4.
+      # CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.).
+      # CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com).
+      # CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other forbidden endpoints.
+      # See https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/networkisolation/resolving-cfs-s360-items
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     sdl:
       sourceAnalysisPool: VSEng-MicroBuildVSStable
       credscan:


### PR DESCRIPTION
Add networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3 to all 7 pipeline YAML files to satisfy SFI-ES4.2.4 compliance requirements.

- CFSClean blocks public package feed endpoints (nuget.org, npmjs.org, etc.)
- CFSClean2 blocks PowerShell Gallery endpoints (powershellgallery.com)
- CFSClean3 blocks Docker, Debian, Hashicorp, SourceForge, and other endpoints